### PR TITLE
RDK-55089: Update rdk-gstreamer-realtek to support NRDP7

### DIFF
--- a/conf/include/rdk-headers-versions.inc
+++ b/conf/include/rdk-headers-versions.inc
@@ -37,6 +37,6 @@ PV:pn-iarmbus-headers = "1.0.1"
 PR:pn-iarmbus-headers = "r0"
 SRCREV:pn-iarmbus-headers = "6ed35ebb886a8ac01812d8bfe5b4c3a89f9ace38"
 
-PV:pn-rdk-gstreamer-utils-headers = "1.0.0"
+PV:pn-rdk-gstreamer-utils-headers = "2.0.0"
 PR:pn-rdk-gstreamer-utils-headers = "r0"
-SRCREV:pn-rdk-gstreamer-utils-headers = "ceb1e846dc1c959dae401db6036bd133fecc9d52"
+SRCREV:pn-rdk-gstreamer-utils-headers = "9487cb4b5354c9a9a788df6fa1f517041dccdd9b"


### PR DESCRIPTION
Reason for change: Sync this layer with stable2 branch that contains the implementation of APIs that are needed by NRDP7 (https://github.com/rdkcentral/gstreamer-netflix-platform/pull/5) MERGED Test Procedure: Check Compilation and Netflix app launch Risks: Low
Priority:
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>