### PR TITLE
RDKEMW-4105: RDK-E Update MW Manifests OSS Release 4.6.0

### DIFF
--- a/conf/include/rdk-headers-versions.inc
+++ b/conf/include/rdk-headers-versions.inc
@@ -37,6 +37,6 @@ PV:pn-iarmbus-headers = "1.0.1"
 PR:pn-iarmbus-headers = "r0"
 SRCREV:pn-iarmbus-headers = "6ed35ebb886a8ac01812d8bfe5b4c3a89f9ace38"
 
-PV:pn-rdk-gstreamer-utils-headers = "2.0.0"
+#PV:pn-rdk-gstreamer-utils-headers = "2.0.0"
 PR:pn-rdk-gstreamer-utils-headers = "r0"
-SRCREV:pn-rdk-gstreamer-utils-headers = "f6e7e0c0e09e67785d0c59531719b970bbe32c86"
+#SRCREV:pn-rdk-gstreamer-utils-headers = "f6e7e0c0e09e67785d0c59531719b970bbe32c86"

--- a/conf/include/rdk-headers-versions.inc
+++ b/conf/include/rdk-headers-versions.inc
@@ -37,6 +37,6 @@ PV:pn-iarmbus-headers = "1.0.1"
 PR:pn-iarmbus-headers = "r0"
 SRCREV:pn-iarmbus-headers = "6ed35ebb886a8ac01812d8bfe5b4c3a89f9ace38"
 
-PV:pn-rdk-gstreamer-utils-headers = "1.0.0"
+PV:pn-rdk-gstreamer-utils-headers = "2.0.0"
 PR:pn-rdk-gstreamer-utils-headers = "r0"
-SRCREV:pn-rdk-gstreamer-utils-headers = "ceb1e846dc1c959dae401db6036bd133fecc9d52"
+SRCREV:pn-rdk-gstreamer-utils-headers = "f6e7e0c0e09e67785d0c59531719b970bbe32c86"

--- a/recipes-rdk-headers/rdk-gstreamer-utils/rdk-gstreamer-utils-headers.bb
+++ b/recipes-rdk-headers/rdk-gstreamer-utils/rdk-gstreamer-utils-headers.bb
@@ -4,6 +4,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 ALLOW_EMPTY:${PN} = "1"
 
+PV = "${@bb.utils.contains('DISTRO_FEATURES', 'RDKE_PLATFORM_STB', "1.0.0", "2.0.0", d)}"
+SRCREV = "${@bb.utils.contains('DISTRO_FEATURES', 'RDKE_PLATFORM_STB', "ceb1e846dc1c959dae401db6036bd133fecc9d52", "f6e7e0c0e09e67785d0c59531719b970bbe32c86", d)}"
+
 SRC_URI = "${CMF_GITHUB_ROOT}/gstreamer-netflix-platform;${CMF_GITHUB_SRC_URI_SUFFIX}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
RDKEMW-4105: RDK-E Update MW Manifests OSS Release 4.6.0

Reason for change: 
	RDK-E Update MW Manifests OSS Release 4.6.0
	     
	
Test Procedure: None
Risks: Low

Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>