### PR TITLE
RDK-55089: Update rdk-gstreamer-realtek to support NRDP7

### DIFF
--- a/conf/include/rdk-headers-versions.inc
+++ b/conf/include/rdk-headers-versions.inc
@@ -29,9 +29,9 @@ PV:pn-tvsettings-hal-headers = "2.2.0"
 PR:pn-tvsettings-hal-headers = "r0"
 SRCREV:pn-tvsettings-hal-headers ="20378fd9a044dc0ebd63a8257ab63f4a643fa05e"
 
-PV:pn-iarmmgrs-hal-headers = "1.0.11"
+PV:pn-iarmmgrs-hal-headers = "1.0.12"
 PR:pn-iarmmgrs-hal-headers = "r0"
-SRCREV:pn-iarmmgrs-hal-headers = "27db67b77bcb2c520a19e0235740d3e3903bb619"
+SRCREV:pn-iarmmgrs-hal-headers = "2ec0b6f6caa662f86963e58c417e8e54e221c99b"
 
 PV:pn-iarmbus-headers = "1.0.1"
 PR:pn-iarmbus-headers = "r0"

--- a/conf/include/rdk-headers-versions.inc
+++ b/conf/include/rdk-headers-versions.inc
@@ -29,9 +29,9 @@ PV:pn-tvsettings-hal-headers = "2.2.0"
 PR:pn-tvsettings-hal-headers = "r0"
 SRCREV:pn-tvsettings-hal-headers ="20378fd9a044dc0ebd63a8257ab63f4a643fa05e"
 
-PV:pn-iarmmgrs-hal-headers = "1.0.1"
+PV:pn-iarmmgrs-hal-headers = "1.0.10"
 PR:pn-iarmmgrs-hal-headers = "r0"
-SRCREV:pn-iarmmgrs-hal-headers = "adf1e71ca349754e772d352b8afac0a149882ef1"
+SRCREV:pn-iarmmgrs-hal-headers = "ef4b29a09838980c088eff91fa48d269bd105582"
 
 PV:pn-iarmbus-headers = "1.0.1"
 PR:pn-iarmbus-headers = "r0"

--- a/conf/include/rdk-headers-versions.inc
+++ b/conf/include/rdk-headers-versions.inc
@@ -37,6 +37,6 @@ PV:pn-iarmbus-headers = "1.0.1"
 PR:pn-iarmbus-headers = "r0"
 SRCREV:pn-iarmbus-headers = "6ed35ebb886a8ac01812d8bfe5b4c3a89f9ace38"
 
-PV:pn-rdk-gstreamer-utils-headers = "1.0.0"
+PV:pn-rdk-gstreamer-utils-headers = "2.0.0"
 PR:pn-rdk-gstreamer-utils-headers = "r0"
-SRCREV:pn-rdk-gstreamer-utils-headers = "ceb1e846dc1c959dae401db6036bd133fecc9d52"
+SRCREV:pn-rdk-gstreamer-utils-headers = "f6e7e0c0e09e67785d0c59531719b970bbe32c86"

--- a/conf/include/rdk-headers-versions.inc
+++ b/conf/include/rdk-headers-versions.inc
@@ -29,9 +29,9 @@ PV:pn-tvsettings-hal-headers = "2.2.0"
 PR:pn-tvsettings-hal-headers = "r0"
 SRCREV:pn-tvsettings-hal-headers ="20378fd9a044dc0ebd63a8257ab63f4a643fa05e"
 
-PV:pn-iarmmgrs-hal-headers = "1.0.10"
+PV:pn-iarmmgrs-hal-headers = "1.0.11"
 PR:pn-iarmmgrs-hal-headers = "r0"
-SRCREV:pn-iarmmgrs-hal-headers = "ef4b29a09838980c088eff91fa48d269bd105582"
+SRCREV:pn-iarmmgrs-hal-headers = "27db67b77bcb2c520a19e0235740d3e3903bb619"
 
 PV:pn-iarmbus-headers = "1.0.1"
 PR:pn-iarmbus-headers = "r0"

--- a/recipes-rdk-headers/iarmmgrs/iarmmgrs-hal-headers_git.bb
+++ b/recipes-rdk-headers/iarmmgrs/iarmmgrs-hal-headers_git.bb
@@ -28,7 +28,6 @@ RDEPENDS:${PN}-dev = ""
 do_install() {
     install -d ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/hal/include/comcastIrKeyCodes.h ${D}${includedir}/rdk/iarmmgrs-hal
-    install -m 0644 ${S}/hal/include/plat_ir.h ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/hal/include/pwrMgr.h ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/hal/include/therm_mon.h ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/ir/irMgrInternal.h ${D}${includedir}/rdk/iarmmgrs-hal

--- a/recipes-rdk-headers/iarmmgrs/iarmmgrs-hal-headers_git.bb
+++ b/recipes-rdk-headers/iarmmgrs/iarmmgrs-hal-headers_git.bb
@@ -30,8 +30,6 @@ do_install() {
     install -m 0644 ${S}/hal/include/comcastIrKeyCodes.h ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/hal/include/pwrMgr.h ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/hal/include/therm_mon.h ${D}${includedir}/rdk/iarmmgrs-hal
-    install -m 0644 ${S}/ir/irMgrInternal.h ${D}${includedir}/rdk/iarmmgrs-hal
-    install -m 0644 ${S}/ir/IrInputRemoteKeyCodes.h ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/power/pwrlogger.h ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/mfr/include/mfrMgr.h ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/mfr/include/mfrTypes.h ${D}${includedir}/rdk/iarmmgrs-hal
@@ -39,7 +37,6 @@ do_install() {
     install -m 0644 ${S}/mfr/include/mfr_wifi_types.h ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/mfr/include/mfr_wifi_api.h ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/mfr/include/mfr_temperature.h ${D}${includedir}/rdk/iarmmgrs-hal
-    install -m 0644 ${S}/ir/include/irMgr.h ${D}${includedir}/rdk/iarmmgrs-hal
     install -m 0644 ${S}/sysmgr/include/sysMgr.h ${D}${includedir}/rdk/iarmmgrs-hal
 
     install -m 0644 ${S}/deviceUpdateMgr/include/deviceUpdateMgr.h ${D}${includedir}/rdk/iarmmgrs-hal


### PR DESCRIPTION
Reason for change: Sync this layer with stable2 branch that contains the implementation of APIs that are needed by NRDP7 (https://github.com/rdkcentral/gstreamer-netflix-platform/pull/5) MERGED Test Procedure: Check Compilation and Netflix app launch Risks: Low
Priority:

(cherry picked from commit b1d7ec0cbc3e88f4ba18d0f07a737283690d0233)