### PR TITLE
RDKEMW-5413 : Remove RF4CE HAL from the middleware layer

### DIFF
--- a/conf/include/rdk-headers-versions.inc
+++ b/conf/include/rdk-headers-versions.inc
@@ -37,7 +37,7 @@ PV:pn-iarmbus-headers = "1.0.1"
 PR:pn-iarmbus-headers = "r0"
 SRCREV:pn-iarmbus-headers = "6ed35ebb886a8ac01812d8bfe5b4c3a89f9ace38"
 
-PV:pn-ctrlm-hal-headers = "1.0.1"
+PV:pn-ctrlm-hal-headers = "1.1.0"
 PR:pn-ctrlm-hal-headers = "r0"
 SRCREV:pn-ctrlm-hal-headers = "99d9e3bda6e59542970eadcdcaaa825d6d5875e8"
 

--- a/recipes-rdk-halif-headers/ctrlm/ctrlm-hal-headers.bb
+++ b/recipes-rdk-halif-headers/ctrlm/ctrlm-hal-headers.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 ALLOW_EMPTY:${PN} = "1"
 
-SRC_URI = "${CMF_GITHUB_ROOT}/control;${CMF_GITHUB_SRC_URI_SUFFIX};name=ctrlm-headers"
+SRC_URI = "${CMF_GITHUB_ROOT}/control;${CMF_GITHUB_SRC_URI_SUFFIX};name=ctrlm-hal-headers"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Adding ctrlm hal headers