### PR TITLE
RDKEVD-2353: Move Playready DRM abstracted API to separae shared obj

### DIFF
--- a/conf/include/rdk-headers-versions.inc
+++ b/conf/include/rdk-headers-versions.inc
@@ -43,7 +43,7 @@ SRCREV:pn-ctrlm-hal-headers = "99d9e3bda6e59542970eadcdcaaa825d6d5875e8"
 
 PV:pn-rdk-gstreamer-utils-headers = "2.0.1"
 PR:pn-rdk-gstreamer-utils-headers = "r0"
-SRCREV:pn-rdk-gstreamer-utils-headers = "9b3c2833cda4e2c3865a75932c2510613037fe61"
+SRCREV:pn-rdk-gstreamer-utils-headers = "bfd86fce3e8d71264623cc9a2b2c7736143f9678"
 
 PV:pn-ctrlm-irdb-headers = "1.1.0"
 PR:pn-ctrlm-irdb-headers = "r0"


### PR DESCRIPTION
Reason for change: Changed function name typo
Risks: None
Priority: P1