### PR TITLE
RDKEVD-7973: Replace vendor reboot reason script from shell to C

### DIFF
--- a/conf/include/rdk-headers-versions.inc
+++ b/conf/include/rdk-headers-versions.inc
@@ -52,3 +52,7 @@ SRCREV:pn-ctrlm-irdb-headers = "7706a0cfc7af9823854d5f6865bb5548a0543494"
 PV:pn-xr-voice-sdk-ffv-headers = "1.0.11"
 PR:pn-xr-voice-sdk-ffv-headers = "r0"
 SRCREV:pn-xr-voice-sdk-ffv-headers = "c047a8aae52f4fc0c88a22b20c8d49da5d856066"
+
+PV:pn-reboot-manager-headers = "1.0.0"
+PR:pn-reboot-manager-headers = "r0"
+SRCREV:pn-reboot-manager-headers = "5159f7b5e18908647604e2a50fb1698d567949a5"

--- a/recipes-rdk-halif-headers/rebootmanager/reboot-manager-headers.bb
+++ b/recipes-rdk-halif-headers/rebootmanager/reboot-manager-headers.bb
@@ -1,0 +1,25 @@
+# Version and SRCREV for this component is handled in conf/include/rdk-headers-versions.inc
+
+SUMMARY = "This recipe provides RDK Reboot Manager HAL Interface headers"
+SECTION = "console/utils"
+
+LICENSE = "CLOSED"
+
+inherit allarch
+
+SRC_URI = "${CMF_GITHUB_ROOT}/rdk-halif-reboot-manager;${CMF_GITHUB_SRC_URI_SUFFIX}"
+
+S = "${WORKDIR}/git"
+
+# this is a Header package only, nothing to build
+do_compile[noexec] = "1"
+do_configure[noexec] = "1"
+
+
+do_install() {
+        install -d ${D}${includedir}/rdk/halif/reboot-manager
+        install -m 0644 ${S}/include/*.h ${D}${includedir}/rdk/halif/reboot-manager
+}
+
+#PACKAGES = "${PN}-dev"
+#FILES:${PN}-dev = "${includedir}/rdk/halif/reboot-manager/*.h"


### PR DESCRIPTION
Reason for change: Added code for Reboot reason
Test Procedure: None
Risks: P1
Signed-off-by: najeemabegami <najeemabegam.iqbal@sky.uk>

JIRA : https://ccp.sys.comcast.net/browse/RDKEVD-7973